### PR TITLE
Newer pythons

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,38 @@
+name: check
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  test:
+    name: test ${{ matrix.py }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - Ubuntu
+          - Windows
+          - MacOs
+        py:
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
+          - "3.6"
+    steps:
+      - name: Setup python for test ${{ matrix.py }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.py }}
+      - uses: actions/checkout@v2
+      - name: Install tox-gh
+        run: python -m pip install tox-gh
+      - name: Setup test suite
+        run: tox4 r -vv --notest
+      - name: Run test suite
+        run: tox4 r --skip-pkg-install
+        env:
+          PYTEST_ADDOPTS: "-vv --durations=10"

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ SHORT_PYVER = $(basename $(LONG_PYVER))
 .PHONY: install package install_wheel audit manylinux all ensure clean test
 
 install: ast.c
-	$(PY) setup.py build install
+	$(PY) -m pip install .[dev]
 
 package: ast.c
-	$(PY) setup.py sdist bdist_wheel
+	$(PY) -m build
 
 install_wheel: package
 	$(PY) -m pip install `$(PY) ./test/utils/find_wheel.py ./dist/`

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ SHORT_PYVER = $(basename $(LONG_PYVER))
 
 .PHONY: install package install_wheel audit manylinux all ensure clean test
 
+ML_PYTHONS:=$(foreach py,cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310,/opt/python/$(py)/bin/python)
+PYTHONS:=python3.6 python3.7 python3.8 python3.9 python3.10
+
 install: ast.c
 	$(PY) -m pip install .[dev]
 
@@ -21,10 +24,10 @@ audit: package
 	rm ./dist/*$(subst .,,$(SHORT_PYVER))*-linux_*.whl
 
 manylinux:
-	$(foreach py, /opt/python/cp36-cp36m/bin/python /opt/python/cp37-cp37m/bin/python /opt/python/cp38-cp38/bin/python, $(MAKE) -f $(FYEAH_MAKE) audit PY=$(py);)
+	$(foreach py, $(ML_PYTHONS), $(MAKE) -f $(FYEAH_MAKE) audit PY=$(py);)
 
 all:
-	$(foreach py, python3.6 python3.7 python3.8, $(MAKE) -f $(FYEAH_MAKE) package PY=$(py);)
+	$(foreach py, $(PYTHONS), $(MAKE) -f $(FYEAH_MAKE) package PY=$(py);)
 
 build:
 	mkdir ./build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,7 @@ name = "material"
 favicon = "art/logo.png"
 logo = "art/logo.png"
 palette = {primary = "black", accent = "gray"}
+
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     version="0.2.0",
     author="Jeremiah Paige",
     author_email="ucodery@gmail.com",
-    python_requires=">=3.6, <3.9",
+    python_requires=">=3.6, <3.11",
     packages=["fyeah"],
     ext_modules=[cmodule],
     extras_require={
@@ -36,6 +36,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,11 @@ changedir = {toxinidir}
 commands =
     black fyeah/ setup.py
     black -S test/
+
+[gh]
+python =
+    3.6 = py36
+    3.7 = py37
+    3.8 = py38
+    3.9 = py39
+    3.10 = py310

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}{,-wheel},py-black
+envlist = py{36,37,38,39,310}{,-wheel},py-black
 skipsdist = true
 
 [testenv]
@@ -11,8 +11,8 @@ changedir = test
 setenv =
     HOME = {env:HOME}
 commands_pre =
-    py{36,37,38}: make -C {toxinidir} install
-    py{36,37,38}-wheel: make -C {toxinidir} install_wheel
+    py{36,37,38,39,310}: make -C {toxinidir} install
+    py{36,37,38,39,310}-wheel: make -C {toxinidir} install_wheel
 commands =
     python -m pytest
 


### PR DESCRIPTION
Since I really like the library, but have a restriction to python 3.9, I wanted to see if that's easily addable.

I've added a setup for Github actions to check, and after a bit of tweaking the setup, I end up with an error that I do not understand: https://github.com/renefritze/fyeah/runs/5627444542?check_suite_focus=true#step:6:77

The symbol in question is in (my) libpython3.9.so however.